### PR TITLE
Fix levelname Mapping and deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 env:
   - DATADEPS_ALWAY_ACCEPT=true
 julia:
-  - 0.6
+  - 1.0
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
 #  - osx
 env:
-  - DATADEPS_ALWAY_ACCEPT=true
+  - DATADEPS_ALWAYS_ACCEPT=true
 julia:
   - 1.0
   - nightly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,17 @@
 environment:
-  DATADEPS_ALWAY_ACCEPT: True
+  DATADEPS_ALWAYS_ACCEPT: True
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 1.0
+  - julia_version: nightly
+
+platform:
+  - x86
+  - x64
+
 matrix:
   allow_failures:
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: nightly
+
 branches:
   only:
     - master
@@ -21,19 +24,12 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"CorpusLoaders\"); Pkg.build(\"CorpusLoaders\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"CorpusLoaders\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/src/CorpusLoaders.jl
+++ b/src/CorpusLoaders.jl
@@ -12,13 +12,12 @@ export load
 
 export WikiCorpus, SemCor, Senseval3
 
-file_path = dirname(@__FILE__)
 
 function __init__()
-    include(joinpath(file_path, "WikiCorpus_DataDeps.jl"))
-    include(joinpath(file_path, "SemCor_DataDeps.jl"))
-    include(joinpath(file_path, "SemEval2007Task7_DataDeps.jl"))
-    include(joinpath(file_path, "Senseval3_DataDeps.jl"))
+    include(joinpath(@__DIR__, "WikiCorpus_DataDeps.jl"))
+    include(joinpath(@__DIR__, "SemCor_DataDeps.jl"))
+    include(joinpath(@__DIR__, "SemEval2007Task7_DataDeps.jl"))
+    include(joinpath(@__DIR__, "Senseval3_DataDeps.jl"))
 end
 
 include("types.jl")

--- a/src/CorpusLoaders.jl
+++ b/src/CorpusLoaders.jl
@@ -12,12 +12,13 @@ export load
 
 export WikiCorpus, SemCor, Senseval3
 
-function __init__()
+file_path = dirname(@__FILE__)
 
-    include("WikiCorpus_DataDeps.jl")
-    include("SemCor_DataDeps.jl")
-    include("SemEval2007Task7_DataDeps.jl")
-    include("Senseval3_DataDeps.jl")
+function __init__()
+    include(joinpath(file_path, "WikiCorpus_DataDeps.jl"))
+    include(joinpath(file_path, "SemCor_DataDeps.jl"))
+    include(joinpath(file_path, "SemEval2007Task7_DataDeps.jl"))
+    include(joinpath(file_path, "Senseval3_DataDeps.jl"))
 end
 
 include("types.jl")

--- a/src/SemCor.jl
+++ b/src/SemCor.jl
@@ -22,7 +22,7 @@ end
 SemCor() = SemCor(datadep"SemCor 3.0")
 
 MultiResolutionIterators.levelname_map(::Type{SemCor}) = [
-    :doc=>1, :contextfile=>1, :context=>1,
+    :doc=>1, :contextfile=>1, :context=>1, :document=>1,
     :para=>2, :paragraph=>2,
     :sent=>3, :sentence=>3,
     :word=>4, :token=>4,

--- a/src/SemCor.jl
+++ b/src/SemCor.jl
@@ -80,7 +80,7 @@ function parse_semcorfile(filename)
     subparsers = [
         "<wf cmd=tag"=>          get_tagged,
         "<wf cmd=ignore"=>       get_tagged,
-        "<wf cmd=done"=>         line -> contains(line,"lemma=") ? get_sense_annotated(line) : get_tagged(line),
+        "<wf cmd=done"=>         line -> occursin("lemma=", line) ? get_sense_annotated(line) : get_tagged(line),
         "<punc>"=>               get_punc,
         "<context"=>             ignore,
         "</context" =>           ignore,

--- a/src/Senseval3.jl
+++ b/src/Senseval3.jl
@@ -58,7 +58,7 @@ function parse_senseval3file(filename)
     subparsers = [
         "<wf cmd=tag"=>          get_tagged,
         "<wf cmd=ignore"=>       get_tagged,
-        "<wf cmd=done"=>         line -> contains(line,"lemma=") ? get_sense_annotated(line) : get_tagged(line),
+        "<wf cmd=done"=>         line -> occursin("lemma=", line) ? get_sense_annotated(line) : get_tagged(line),
         "<punc>"=>               get_punc,
         "<context"=>             ignore,
         "</context" =>           ignore,

--- a/src/Senseval3.jl
+++ b/src/Senseval3.jl
@@ -16,10 +16,10 @@ end
 Senseval3() = Senseval3(datadep"Senseval 3")
 
 MultiResolutionIterators.levelname_map(::Type{Senseval3}) = [
-    :doc=>1, :contextfile=>1, :context=>1,
+    :doc=>1, :contextfile=>1, :context=>1, :document=>1,
     :sent=>2, :sentence=>2,
     :word=>3, :token=>3,
-    :char=>4, :character=>5
+    :char=>4, :character=>4
     ]
 
 

--- a/src/WikiCorpus.jl
+++ b/src/WikiCorpus.jl
@@ -4,12 +4,13 @@ end
 WikiCorpus() = WikiCorpus(datadep"English WikiCorpus v1.0")
 
 MultiResolutionIterators.levelname_map(::Type{WikiCorpus}) = [
-    :doc=>1,
+    :doc=>1, :document=>1,
     :section=>2,
-    :para=>3, :line=>3,
-    :sent=>4,
+    :para=>3, :line=>3, :paragraph=>3,
+    :sent=>4, :sentence=>4,
     :word=>5, :token=>5,
-    :char=>6]
+    :char=>6, :character=>6
+    ]
 
 """
     push_nonempty!(xss, xs)

--- a/src/apply_subparsers.jl
+++ b/src/apply_subparsers.jl
@@ -20,7 +20,7 @@ function apply_subparsers(filename, subparsers)
             end
             @assert(found, "No parser for \"$line\"")
         catch ee
-            warn("Error parsing \"$line\". $ee")
+            @warn "Error parsing \"$line\". $ee"
             rethrow()
         end
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -2,22 +2,21 @@
 # The inner iterator must be in the `content` field
 
 abstract type AnnotatedIterator{T} end
-function Base.iteratoreltype(::Type{<:AnnotatedIterator{T}}) where T
-     Base.iteratoreltype(T)
+function Base.IteratorEltype(::Type{<:AnnotatedIterator{T}}) where T
+     Base.IteratorEltype(T)
  end
-function Base.iteratorsize(::Type{AnnotatedIterator{T}}) where T
-    Base.iteratorsize(T)
+function Base.IteratorSize(::Type{AnnotatedIterator{T}}) where T
+    Base.IteratorSize(T)
 end
 function Base.IndexStyle(::Type{AnnotatedIterator{T}}) where T
     Base.IndexStyle(T)
 end
 
-Base.start(aiter::AnnotatedIterator)=Base.start(aiter.content)
-Base.next(aiter::AnnotatedIterator, state)=Base.next(aiter.content, state)
-Base.done(aiter::AnnotatedIterator, state)=Base.done(aiter.content, state)
+Base.iterate(aiter::AnnotatedIterator) = Base.iterate(aiter.content)
+Base.iterate(aiter::AnnotatedIterator, state) = Base.iterate(aiter.content, state)
 
 Base.length(aiter::AnnotatedIterator) = length(aiter.content)
-Base.endof(aiter::AnnotatedIterator) = endof(aiter.content)
+Base.lastindex(aiter::AnnotatedIterator) = lastindex(aiter.content)
 
 Base.getindex(aiter::AnnotatedIterator, args...) = getindex(aiter.content, args...)
 Base.setindex!(aiter::AnnotatedIterator, args...) = setindex!(aiter.content, args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 using CorpusLoaders
 
 files = ["types",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,9 @@ using Test
 using CorpusLoaders
 
 files = ["types",
-         "wikicorpus",
          "SemCor",
-         "Senseval3"
+         "Senseval3",
+         "wikicorpus"
         ]
 
 

--- a/test/test_SemCor.jl
+++ b/test/test_SemCor.jl
@@ -1,5 +1,5 @@
 using CorpusLoaders
-using Base.Test
+using Test
 using Base.Iterators
 using MultiResolutionIterators
 
@@ -11,7 +11,7 @@ using MultiResolutionIterators
     words = consolidate(flatten_levels(docs, (!lvls)(SemCor, :word)))
     @test length(words) > length(docs)
     @test length(words) > sum(length.(docs))
-    @test typeof(words) == Vector{CorpusLoaders.TaggedWord}
+    @test typeof(words) == Vector{TaggedWord}
 
     plain_words = word.(words)
     @test typeof(plain_words) <: Vector{String}

--- a/test/test_SemCor.jl
+++ b/test/test_SemCor.jl
@@ -2,7 +2,7 @@ using CorpusLoaders
 using Test
 using Base.Iterators
 using MultiResolutionIterators
-
+using DataDeps
 
 @testset "basic use" for path in [datadep"SemCor 1.6", datadep"SemCor 1.7", datadep"SemCor 1.7.1", datadep"SemCor 2.0", datadep"SemCor 3.0", datadep"SemCor 3.0/brownv"]
     wk_gen = load(SemCor(path))

--- a/test/test_Senseval3.jl
+++ b/test/test_Senseval3.jl
@@ -1,11 +1,10 @@
 using CorpusLoaders
 using Test
 using Base.Iterators
-using MultiResolutionIterators, DataDeps
+using MultiResolutionIterators
 
 @testset "Basic use" begin
-    path = datadep"Senseval 3"
-    wk_gen = load(Senseval3(path))
+    wk_gen = load(Senseval3())
     docs = collect(take(wk_gen,10));
 
     words = consolidate(flatten_levels(docs, (!lvls)(Senseval3, :word)))

--- a/test/test_Senseval3.jl
+++ b/test/test_Senseval3.jl
@@ -1,12 +1,12 @@
 using CorpusLoaders
-using Base.Test
+using Test
 using Base.Iterators
-using MultiResolutionIterators
+using MultiResolutionIterators, DataDeps
 
 @testset "Basic use" begin
     path = datadep"Senseval 3"
     wk_gen = load(Senseval3(path))
-    docs = collect(wk_gen);
+    docs = collect(take(wk_gen,10));
 
     words = consolidate(flatten_levels(docs, (!lvls)(Senseval3, :word)))
     @test length(words) > length(docs)

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 using CorpusLoaders
 using CorpusLoaders: @NestedVector
 using MultiResolutionIterators

--- a/test/test_wikicorpus.jl
+++ b/test/test_wikicorpus.jl
@@ -1,16 +1,16 @@
 using CorpusLoaders
-using Base.Test
+using Test
 using Base.Iterators
 using MultiResolutionIterators
 using InternedStrings
 
 @testset "basic use" begin
     wk_gen = load(WikiCorpus())
-    docs = collect(take(wk_gen, 10));
+    docs = collect(take(wk_gen, 5));
 
 
     @test typeof(docs) ==
-        Vector{Document{CorpusLoaders.@NestedVector(String, 4), String}}
+        Vector{CorpusLoaders.Document{@NestedVector(String, 4), String}}
 #    @test all(isa.(words, AbstractString))
 #    @test "a" ∈ words
 #    @test "the" ∈ words
@@ -25,13 +25,11 @@ using InternedStrings
     #Make sure we're not catching anything we shouldn't
     @test "ENDOFARTICLE" ∉ vocab
     @test "ENDOFARTICLE." ∉ vocab
-    @test "<doc" ∉ map(x->x[1:min(end,4)], vocab)
-
-
+    # @test "<doc" ∉ map(x->x[1:min(end,4)], vocab)
 
 
     docs_of_words = full_consolidate(flatten_levels(docs, (!lvls)(WikiCorpus, :doc, :word)))
-    @test typeof(docs_of_words) == Vector{Document{Vector{String}, String}}
+    @test typeof(docs_of_words) == Vector{CorpusLoaders.Document{Vector{String}, String}}
     @test length(docs_of_words) == length(docs)
     @test sum(length.(docs_of_words)) == length(words)
 end

--- a/test/test_wikicorpus.jl
+++ b/test/test_wikicorpus.jl
@@ -25,7 +25,7 @@ using InternedStrings
     #Make sure we're not catching anything we shouldn't
     @test "ENDOFARTICLE" ∉ vocab
     @test "ENDOFARTICLE." ∉ vocab
-    # @test "<doc" ∉ map(x->x[1:min(end,4)], vocab)
+    @test "<doc" ∉ Set([x[1:min(end, 4)] for x in vocab])
 
 
     docs_of_words = full_consolidate(flatten_levels(docs, (!lvls)(WikiCorpus, :doc, :word)))

--- a/test/test_wikicorpus.jl
+++ b/test/test_wikicorpus.jl
@@ -4,32 +4,37 @@ using Base.Iterators
 using MultiResolutionIterators
 using InternedStrings
 
-@testset "basic use" begin
-    wk_gen = load(WikiCorpus())
-    docs = collect(take(wk_gen, 5));
+if ENV["CI"]=="true" && ENV["TRAVIS"]=="true"
+    @warn "WikiCorpus tests disabled on TravisCI"
+else
+    # Do the tests
+    @testset "basic use" begin
+        wk_gen = load(WikiCorpus())
+        docs = collect(take(wk_gen, 5));
 
 
-    @test typeof(docs) ==
+        @test typeof(docs) ==
         Vector{CorpusLoaders.Document{@NestedVector(String, 4), String}}
-#    @test all(isa.(words, AbstractString))
-#    @test "a" ∈ words
-#    @test "the" ∈ words
-    words = collect(flatten_levels(docs, (!lvls)(WikiCorpus, :word)))
-    @test typeof(words) == Vector{String}
-    @test length(words) >= length(docs)
+        #    @test all(isa.(words, AbstractString))
+        #    @test "a" ∈ words
+        #    @test "the" ∈ words
+        words = collect(flatten_levels(docs, (!lvls)(WikiCorpus, :word)))
+        @test typeof(words) == Vector{String}
+        @test length(words) >= length(docs)
 
-    vocab = Set(words)
-    @test "the" ∈ vocab
-    @test "a" ∈ vocab
+        vocab = Set(words)
+        @test "the" ∈ vocab
+        @test "a" ∈ vocab
 
-    #Make sure we're not catching anything we shouldn't
-    @test "ENDOFARTICLE" ∉ vocab
-    @test "ENDOFARTICLE." ∉ vocab
-    @test "<doc" ∉ Set([x[1:min(end, 4)] for x in vocab])
+        #Make sure we're not catching anything we shouldn't
+        @test "ENDOFARTICLE" ∉ vocab
+        @test "ENDOFARTICLE." ∉ vocab
+        @test "<doc" ∉ Set([x[1:min(end, 4)] for x in vocab])
 
 
-    docs_of_words = full_consolidate(flatten_levels(docs, (!lvls)(WikiCorpus, :doc, :word)))
-    @test typeof(docs_of_words) == Vector{CorpusLoaders.Document{Vector{String}, String}}
-    @test length(docs_of_words) == length(docs)
-    @test sum(length.(docs_of_words)) == length(words)
+        docs_of_words = full_consolidate(flatten_levels(docs, (!lvls)(WikiCorpus, :doc, :word)))
+        @test typeof(docs_of_words) == Vector{CorpusLoaders.Document{Vector{String}, String}}
+        @test length(docs_of_words) == length(docs)
+        @test sum(length.(docs_of_words)) == length(words)
+    end
 end


### PR DESCRIPTION
Fixed `MultiResolutionIterators.levelname_map` here and added more in others. https://github.com/JuliaText/CorpusLoaders.jl/blob/2bb7d7e0b4a04fc534f6e4900f4e9a2b04c30945/src/Senseval3.jl#L22