### PR TITLE
Bump to 0.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CorpusLoaders"
 uuid = "214a0ac2-f95b-54f7-a80b-442ed9c2c9e8"
 license = "MIT"
 desc = "A variety of loaders for various NLP corpora."
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"


### PR DESCRIPTION
Since 0.3.0 following changes have been made:
- WikiGold added.
- CoNLL 2000 added.
- PoS for CoNLL 2000 added.
- SemCor 2.1 added. 

I think it's better to release v0.4.0 than v0.3.1. What do you suggest @oxinabox ?
