### PR TITLE
Add Compat entries in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,14 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 
 [compat]
 julia = "1"
+LightXML = "0.8"
+DataDeps = "0.7"
+Glob = "1.2"
+InternedStrings = "0.7"
+StringEncodings = "0.3"
+WordTokenizers = "0.5"
+MultiResolutionIterators = "0.5"
+CSV = "0.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
For auto-merge of release tagging, it is required for the package to have [compat] entries for all dependencies. (and otherwise too strongly recommended) https://github.com/JuliaRegistries/General/pull/7439#issuecomment-570264118 
- [X] Compat entries in Project.toml
- [ ] CompatHelper (?)
https://github.com/bcbi/CompatHelper.jl will help auto update [compat] entries.